### PR TITLE
copywrite: Change "Controler" to "Interface" for more clarity

### DIFF
--- a/status.go
+++ b/status.go
@@ -145,11 +145,11 @@ func disksSection() (result []string, err error) {
 	}
 
 	result = []string{
-		listHeader("Disk"),
+		listHeader("Storage Drives"),
 	}
 
 	for i, disk := range disks {
-		title := "Disk"
+		title := "Drive"
 		if len(disks) > 1 {
 			title = title + string(i)
 		}


### PR DESCRIPTION
first, "Controler" is a typo

and second, it would make more sense for this to be called the "Interface", since this field describes the hardware interface the particular drive is using, not the HBA itself.


Also, we should change the whole usage of "Disk" as "Drives" since this detects more types of storage than disk drives, as it also detects any storage media including ODDs, virtual disks, and Floppy drives (if anyone still uses that in 2025)